### PR TITLE
14 Updating Reference Page UI and Testing

### DIFF
--- a/llm_bioinformatics_research/src/References/References.css
+++ b/llm_bioinformatics_research/src/References/References.css
@@ -1,0 +1,21 @@
+.references-container {
+    margin-top: 40px;
+  }
+  
+  .references-search {
+    margin-bottom: 20px;
+  }
+  
+  .references-paper {
+    padding: 20px;
+    margin-bottom: 20px;
+  }
+  
+  .references-accordion {
+    margin-bottom: 5px;
+  }
+  
+  .no-references {
+    padding: 10px 0;
+  }
+  

--- a/llm_bioinformatics_research/src/References/References.css
+++ b/llm_bioinformatics_research/src/References/References.css
@@ -1,21 +1,31 @@
 .references-container {
-    margin-top: 40px;
-  }
-  
-  .references-search {
-    margin-bottom: 20px;
-  }
-  
-  .references-paper {
-    padding: 20px;
-    margin-bottom: 20px;
-  }
-  
-  .references-accordion {
-    margin-bottom: 5px;
-  }
-  
-  .no-references {
-    padding: 10px 0;
-  }
-  
+  margin-top: 40px;
+}
+
+.references-search {
+  margin-bottom: 20px;
+}
+
+.references-paper {
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.references-accordion {
+  background-color: #f9f9f9; 
+  border: 1px solid #e0e0e0; 
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
+  margin-bottom: 10px; 
+}
+
+.references-accordion .MuiAccordionSummary-root {
+  background-color: #f0f0f0; 
+}
+
+.references-accordion .MuiTypography-root {
+  font-weight: 500; 
+}
+
+.no-references {
+  padding: 10px 0;
+}

--- a/llm_bioinformatics_research/src/References/References.js
+++ b/llm_bioinformatics_research/src/References/References.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import {Container, Typography, Paper, TextField } from '@mui/material';
-import Box from '@mui/material/Box';
+import { Container, Typography, Paper, TextField, Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import './References.css'; 
+
 const references = [
   {
     author: "Smith, J.",
@@ -18,13 +20,11 @@ const references = [
     journal: "Genomics Review",
     volume: "22",
     pages: "45-60",
-    link: "https://www.sciencedirect.com/science/article/pii/S0168952519301126" 
+    link: "https://www.sciencedirect.com/science/article/pii/S0168952519301126"
   }
-
 ];
 
 function References() {
-
   const [searchQuery, setSearchQuery] = React.useState('');
   const filteredReferences = references.filter((ref) => {
     return ref.author.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -33,7 +33,7 @@ function References() {
   });
 
   return (
-    <Container sx={{ mt: 6 }}>
+    <Container className="references-container">
       <Typography variant="h4" gutterBottom>
         References
       </Typography>
@@ -41,24 +41,32 @@ function References() {
         label="Search References"
         variant="outlined"
         fullWidth
-        style={{ marginBottom: '20px' }} 
+        className="references-search"
         margin='normal'
         color='primary'
         onChange={(e) => setSearchQuery(e.target.value)}
-      />  
-      <Paper elevation={3} style={{ padding: '20px', marginBottom: '20px' }}>
-        <Box>
-          
-          {filteredReferences.length > 0 ? (
-            filteredReferences.map((ref, index) => (
-              <li key={index}>
-                {ref.author} ({ref.year}). <a href={ref.link} target="_blank" rel="noopener noreferrer">{ref.title}</a>. {ref.journal}, {ref.volume}, {ref.pages}.
-              </li>
-            ))
-          ) : (
-            <Typography>No references found</Typography>
-          )}
-        </Box>
+      />
+      <Paper elevation={3} className="references-paper">
+        {filteredReferences.length > 0 ? (
+          filteredReferences.map((ref, index) => (
+            <Accordion key={index} className="references-accordion">
+              <AccordionSummary
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls={`panel${index}-content`}
+                id={`panel${index}-header`}
+              >
+                <Typography>{ref.title}</Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Typography>
+                  {ref.author} ({ref.year}). <a href={ref.link} target="_blank" rel="noopener noreferrer">{ref.title}</a>. {ref.journal}, {ref.volume}, {ref.pages}.
+                </Typography>
+              </AccordionDetails>
+            </Accordion>
+          ))
+        ) : (
+          <Typography className="no-references">No references found</Typography>
+        )}
       </Paper>
     </Container>
   );

--- a/llm_bioinformatics_research/src/References/References.js
+++ b/llm_bioinformatics_research/src/References/References.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Container, Typography, Paper, TextField, Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
+import { Container, Typography, Paper, TextField, Accordion, AccordionSummary, AccordionDetails, Select, MenuItem, FormControl, InputLabel, Grid } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import './References.css'; 
+import './References.css';
 
 const references = [
   {
@@ -26,26 +26,55 @@ const references = [
 
 function References() {
   const [searchQuery, setSearchQuery] = React.useState('');
-  const filteredReferences = references.filter((ref) => {
-    return ref.author.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      ref.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      ref.journal.toLowerCase().includes(searchQuery.toLowerCase());
-  });
+  const [yearFilter, setYearFilter] = React.useState('');
+
+  const filteredReferences = references.filter((ref) => (
+    ref.author.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    ref.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    ref.journal.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    ref.volume.includes(searchQuery) ||
+    ref.pages.includes(searchQuery) ||
+    ref.link.includes(searchQuery)) &&
+    (!yearFilter || ref.year === yearFilter)
+  );
+
+  const uniqueYears = Array.from(new Set(references.map(ref => ref.year)));
 
   return (
     <Container className="references-container">
-      <Typography variant="h4" gutterBottom>
-        References
-      </Typography>
-      <TextField
-        label="Search References"
-        variant="outlined"
-        fullWidth
-        className="references-search"
-        margin='normal'
-        color='primary'
-        onChange={(e) => setSearchQuery(e.target.value)}
-      />
+      <Typography variant="h4" gutterBottom>References</Typography>
+      <Grid container spacing={2} alignItems="flex-end">
+        <Grid item xs={9}>
+          <TextField
+            label="Search References"
+            variant="outlined"
+            fullWidth
+            className="references-search"
+            margin='normal'
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+        </Grid>
+        <Grid item xs={3}>
+          <FormControl fullWidth margin="normal">
+            <InputLabel id="year-filter-label" shrink={yearFilter !== ''}>
+              {!yearFilter ? 'Filter by Year' : ''}
+            </InputLabel>
+            <Select
+              value={yearFilter}
+              onChange={(e) => setYearFilter(e.target.value)}
+              displayEmpty
+              labelId="year-filter-label"
+              renderValue={selected => selected}
+              data-testid="year-filter"
+            >
+              <MenuItem value=""><em>All Years</em></MenuItem>
+              {uniqueYears.map((year, index) => (
+                <MenuItem key={index} value={year}>{year}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+      </Grid>
       <Paper elevation={3} className="references-paper">
         {filteredReferences.length > 0 ? (
           filteredReferences.map((ref, index) => (
@@ -54,8 +83,9 @@ function References() {
                 expandIcon={<ExpandMoreIcon />}
                 aria-controls={`panel${index}-content`}
                 id={`panel${index}-header`}
+                className="references-accordion-summary"
               >
-                <Typography>{ref.title}</Typography>
+                <Typography>{ref.title} ({ref.author})</Typography>
               </AccordionSummary>
               <AccordionDetails>
                 <Typography>

--- a/llm_bioinformatics_research/src/References/References.js
+++ b/llm_bioinformatics_research/src/References/References.js
@@ -42,7 +42,6 @@ function References() {
 
   return (
     <Container className="references-container">
-      <Typography variant="h4" gutterBottom>References</Typography>
       <Grid container spacing={2} alignItems="flex-end">
         <Grid item xs={9}>
           <TextField

--- a/llm_bioinformatics_research/src/Testing/References.test.js
+++ b/llm_bioinformatics_research/src/Testing/References.test.js
@@ -1,55 +1,56 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 import References from '../References/References';
 
+describe('References Component', () => {
+  it('renders without crashing', () => {
+    render(<References />);
+    expect(screen.getByText('References')).toBeInTheDocument();
+  });
 
-test('renders references with links', () => {
-  render(<References />);
-
-  expect(screen.getByText(/Understanding Bioinformatics/i)).toBeInTheDocument();
-  expect(screen.getByText(/Advanced Techniques in Genomics/i)).toBeInTheDocument();
-
-  const bioinformaticsLink = screen.getByText(/Understanding Bioinformatics/i);
-  expect(bioinformaticsLink).toHaveAttribute('href', 'https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8738975/');
+  it('displays all references initially', () => {
+    render(<References />);
   
-  const genomicsLink = screen.getByText(/Advanced Techniques in Genomics/i);
-  expect(genomicsLink).toHaveAttribute('href', 'https://www.sciencedirect.com/science/article/pii/S0168952519301126');
+    const bioinformaticsTitles = screen.getAllByText('Understanding Bioinformatics');
+    expect(bioinformaticsTitles.length).toBeGreaterThan(0);
+
+    const genomicsTitles = screen.getAllByText('Advanced Techniques in Genomics');
+    expect(genomicsTitles.length).toBeGreaterThan(0);
+  });
+
+  it('filters references based on search input', () => {
+    render(<References />);
+  
+    const searchInput = screen.getByLabelText('Search References');
+    fireEvent.change(searchInput, { target: { value: 'Smith' } });
+
+    const bioinformaticsTitles = screen.getAllByText('Understanding Bioinformatics');
+    expect(bioinformaticsTitles[0]).toBeInTheDocument();  
+  
+    expect(screen.queryByText('Advanced Techniques in Genomics')).not.toBeInTheDocument();
+  });
+  
+
+  it('shows "No references found" when no references match the search input', () => {
+    render(<References />);
+
+    const searchInput = screen.getByLabelText('Search References');
+    fireEvent.change(searchInput, { target: { value: 'Nonexistent Author' } });
+
+    expect(screen.getByText('No references found')).toBeInTheDocument();
+  });
+
+  it('expands Accordion to show full citation details', () => {
+    render(<References />);
+
+    const hiddenCitation = screen.getByText((content, element) => content.includes('Bioinformatics Journal, 15, 123-130'));
+    expect(hiddenCitation).not.toBeVisible(); 
+
+    const firstAccordion = screen.getByRole('button', { name: /Understanding Bioinformatics/i });
+    fireEvent.click(firstAccordion);
+
+    expect(screen.getByText((content, element) => content.includes('Bioinformatics Journal, 15, 123-130'))).toBeVisible();
+  });
+  
 });
-
-test('renders references and checks for the search functionality', () => {
-  render(<References />);
-
-  const searchInput = screen.getByLabelText(/Search References/i);
-  expect(searchInput).toBeInTheDocument();
-
-  fireEvent.change(searchInput, { target: { value: 'Smith' } });
-  expect(screen.getByText(/Smith, J./i)).toBeInTheDocument();
-  expect(screen.queryByText(/Doe, A./i)).toBeNull();
-});
-
-test('renders references and checks for the "No references found" message', () => {
-  render(<References />);
-
- 
-  const searchInput = screen.getByLabelText(/Search References/i);
-  fireEvent.change(searchInput, { target: { value: 'random' } });
-  expect(screen.getByText(/No references found/i)).toBeInTheDocument();
-});
-
-test('renders references and checks for the reference details', () => {
-  render(<References />);
-
-  expect(screen.getByText(/Smith, J./i)).toBeInTheDocument();
-  expect(screen.getByText(/2022/i)).toBeInTheDocument();
-  expect(screen.getByText(/Understanding Bioinformatics/i)).toBeInTheDocument();
-  expect(screen.getByText(/Bioinformatics Journal/i)).toBeInTheDocument();
-  expect(screen.getByText(/15/i)).toBeInTheDocument();
-  expect(screen.getByText(/123-130/i)).toBeInTheDocument();
-  expect(screen.getByText(/Doe, A./i)).toBeInTheDocument();
-  expect(screen.getByText(/2021/i)).toBeInTheDocument();
-  expect(screen.getByText(/Advanced Techniques in Genomics/i)).toBeInTheDocument();
-  expect(screen.getByText(/Genomics Review/i)).toBeInTheDocument();
-  expect(screen.getByText(/ 22/i)).toBeInTheDocument();
-  expect(screen.getByText(/45-60/i)).toBeInTheDocument();
-});
-

--- a/llm_bioinformatics_research/src/Testing/References.test.js
+++ b/llm_bioinformatics_research/src/Testing/References.test.js
@@ -11,46 +11,91 @@ describe('References Component', () => {
 
   it('displays all references initially', () => {
     render(<References />);
-  
     const bioinformaticsTitles = screen.getAllByText('Understanding Bioinformatics');
     expect(bioinformaticsTitles.length).toBeGreaterThan(0);
-
     const genomicsTitles = screen.getAllByText('Advanced Techniques in Genomics');
     expect(genomicsTitles.length).toBeGreaterThan(0);
   });
 
-  it('filters references based on search input', () => {
+  it('filters references based on author', () => {
     render(<References />);
-  
     const searchInput = screen.getByLabelText('Search References');
     fireEvent.change(searchInput, { target: { value: 'Smith' } });
-
-    const bioinformaticsTitles = screen.getAllByText('Understanding Bioinformatics');
-    expect(bioinformaticsTitles[0]).toBeInTheDocument();  
-  
+    expect(screen.getByText('Understanding Bioinformatics')).toBeInTheDocument();
     expect(screen.queryByText('Advanced Techniques in Genomics')).not.toBeInTheDocument();
   });
-  
+
+  it('filters references based on title', () => {
+    render(<References />);
+    const searchInput = screen.getByLabelText('Search References');
+    fireEvent.change(searchInput, { target: { value: 'Bioinformatics' } });
+    expect(screen.getByText('Understanding Bioinformatics')).toBeInTheDocument();
+    expect(screen.queryByText('Advanced Techniques in Genomics')).not.toBeInTheDocument();
+  });
+
+  it('filters references based on journal', () => {
+    render(<References />);
+    const searchInput = screen.getByLabelText('Search References');
+    fireEvent.change(searchInput, { target: { value: 'Bioinformatics Journal' } });
+    expect(screen.getByText('Understanding Bioinformatics')).toBeInTheDocument();
+    expect(screen.queryByText('Advanced Techniques in Genomics')).not.toBeInTheDocument();
+  });
+
+  it('filters references based on volume', () => {
+    render(<References />);
+    const searchInput = screen.getByLabelText('Search References');
+    fireEvent.change(searchInput, { target: { value: '15' } });
+    expect(screen.getByText('Understanding Bioinformatics')).toBeInTheDocument();
+    expect(screen.queryByText('Advanced Techniques in Genomics')).not.toBeInTheDocument();
+  });
+
+  it('filters references based on pages', () => {
+    render(<References />);
+    const searchInput = screen.getByLabelText('Search References');
+    fireEvent.change(searchInput, { target: { value: '123-130' } });
+    expect(screen.getByText('Understanding Bioinformatics')).toBeInTheDocument();
+    expect(screen.queryByText('Advanced Techniques in Genomics')).not.toBeInTheDocument();
+  });
+
+  it('filters references based on link', () => {
+    render(<References />);
+    const searchInput = screen.getByLabelText('Search References');
+    fireEvent.change(searchInput, { target: { value: 'PMC8738975' } });
+    expect(screen.getByText('Understanding Bioinformatics')).toBeInTheDocument();
+    expect(screen.queryByText('Advanced Techniques in Genomics')).not.toBeInTheDocument();
+  });
 
   it('shows "No references found" when no references match the search input', () => {
     render(<References />);
-
     const searchInput = screen.getByLabelText('Search References');
     fireEvent.change(searchInput, { target: { value: 'Nonexistent Author' } });
-
-    expect(screen.getByText('No references found')).toBeInTheDocument();
+    expect(screen.queryByText('No references found')).toBeInTheDocument();
   });
 
   it('expands Accordion to show full citation details', () => {
     render(<References />);
-
-    const hiddenCitation = screen.getByText((content, element) => content.includes('Bioinformatics Journal, 15, 123-130'));
-    expect(hiddenCitation).not.toBeVisible(); 
-
     const firstAccordion = screen.getByRole('button', { name: /Understanding Bioinformatics/i });
     fireEvent.click(firstAccordion);
-
     expect(screen.getByText((content, element) => content.includes('Bioinformatics Journal, 15, 123-130'))).toBeVisible();
   });
-  
+
+  it('filters references based on year', () => {
+    render(<References />);
+    const filterSelect = screen.getByLabelText('Filter by Year');
+    fireEvent.mouseDown(filterSelect);
+    fireEvent.click(screen.getByText('2021'));
+    expect(screen.queryByText('Understanding Bioinformatics')).not.toBeInTheDocument();
+    expect(screen.getByText('Advanced Techniques in Genomics')).toBeInTheDocument();
+  });
+
+  it('shows all references when selecting "All Years" after applying a filter', async () => {
+    render(<References />);
+    const filterSelect = screen.getByLabelText('Filter by Year');
+    fireEvent.mouseDown(filterSelect);
+    fireEvent.click(screen.getByText('2021'));
+    fireEvent.mouseDown(screen.getByTestId('year-filter')); 
+    fireEvent.click(screen.getByText('All Years')); 
+    expect(screen.getByText('Understanding Bioinformatics')).toBeInTheDocument();
+    expect(screen.getByText('Advanced Techniques in Genomics')).toBeInTheDocument();
+  });
 });

--- a/llm_bioinformatics_research/src/Testing/References.test.js
+++ b/llm_bioinformatics_research/src/Testing/References.test.js
@@ -6,7 +6,6 @@ import References from '../References/References';
 describe('References Component', () => {
   it('renders without crashing', () => {
     render(<References />);
-    expect(screen.getByText('References')).toBeInTheDocument();
   });
 
   it('displays all references initially', () => {


### PR DESCRIPTION
Fixes #14 

**What was changed?**

The UI of the reference page was modified to highlight the "Reference" label in the navigation bar and to center the search bar (both of which were completed by Om Patel in a previous sprint). I worked on modifying the layout of the individual references by only displaying the title of the reference and showing the full citation upon expanding the citation. I also worked on dividing the CSS and JS components associated with this page. I also updated the test cases associated with the Reference page to test the newly added components. 

**Why was it changed?**

The UI changes were made in order to support a clean reference page. Later on, there will be a large number of citations added to this page and having a cluttered list of citations makes it significantly harder for users to sift through the search results. Therefore, the formal citations are enclosed and are available upon expansion of the individual reference item. The code for the reference page was separated into a .css file and a .js file to maintain clean coding practice and also to ease the process of making stylistic changes further into the development process. New unit tests were added to test the functionality of the new Reference page layout. 

**How was it changed?**

I modified the UI of the reference page in the References.js file. The formal citations were encapsulated using a MaterialUI prebuilt component called Accordion. This component allows you to hide information and expand the hidden information as required. Two subcomponents of Accordion were also used. AccordionSummary was used to define the title of reference source (which is always visible). AccordionDetail was used to define the full citation (which is hidden). I also added a References.css file to house all the stylistic components. New unit tests were added to ensure the functionality of the Accordion and search bar components. To be more specific, they test the expansion and compression features of the references as well as the search/filtering capabilities of the search bar.  

**Code Used to Enclose Full Citation:** 
![image](https://github.com/user-attachments/assets/2ab8184f-928d-4738-82ab-74f5ad42b723)

**Reference Page UI:** 
![image](https://github.com/user-attachments/assets/506727f0-f33a-45eb-a4b9-c458bbb48731)