### PR TITLE
Resizing profile image to 100x100 upon upload and adding a unit test for setting avatar image

### DIFF
--- a/llm_bioinformatics_research/src/Testing/UserProfile.test.js
+++ b/llm_bioinformatics_research/src/Testing/UserProfile.test.js
@@ -5,7 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 import UserProfile from '../UserProfile/UserProfile';
 import ThemeContext from '../ThemeContext';
 
-describe('UserProfile Component with Theme Testing', () => {
+describe('UserProfile Component', () => {
   const renderWithThemeContext = (ui, { theme = 'light', toggleTheme } = {}) => {
     return render(
       <MemoryRouter>
@@ -25,7 +25,6 @@ describe('UserProfile Component with Theme Testing', () => {
     expect(screen.getByText(/System Default/i)).toBeInTheDocument();
   });
 
-
   test('renders UserProfile with light theme by default', () => {
     const toggleTheme = jest.fn();
     renderWithThemeContext(<UserProfile />, { theme: 'light', toggleTheme });
@@ -33,7 +32,6 @@ describe('UserProfile Component with Theme Testing', () => {
     const myProfileButton = screen.getByText(/My Profile/i);
     const settingsButton = screen.getByText(/Settings/i);
 
-    // Check that colors are set correctly for light theme
     expect(myProfileButton).toHaveStyle('color: white');
     expect(settingsButton).toHaveStyle('color: black');
   });
@@ -45,9 +43,18 @@ describe('UserProfile Component with Theme Testing', () => {
     const myProfileButton = screen.getByText(/My Profile/i);
     const settingsButton = screen.getByText(/Settings/i);
 
-    // Check that colors are set correctly for dark theme
     expect(myProfileButton).toHaveStyle('color: white');
     expect(settingsButton).toHaveStyle('color: white');
   });
 
+  test('updates avatar image when a new image is uploaded', async () => {
+    const toggleTheme = jest.fn();
+    renderWithThemeContext(<UserProfile />, { theme: 'light', toggleTheme });
+
+    const mockImageData = 'data:image/png;base64,mockImageData';
+    const avatarImage = await screen.findByTestId('avatar');
+    avatarImage.setAttribute('src', mockImageData);
+    
+    expect(avatarImage).toHaveAttribute('src', mockImageData);
+  });
 });

--- a/llm_bioinformatics_research/src/UserProfile/UserProfile.js
+++ b/llm_bioinformatics_research/src/UserProfile/UserProfile.js
@@ -62,7 +62,17 @@ const UserProfile = () => {
     if (file) {
       const reader = new FileReader();
       reader.onloadend = () => {
-        setUser({ ...user, image: reader.result });
+        const img = new Image();
+        img.src = reader.result;
+        img.onload = () => {
+          const canvas = document.createElement('canvas');
+          const ctx = canvas.getContext('2d');
+          canvas.width = 100;
+          canvas.height = 100;
+          ctx.drawImage(img, 0, 0, 100, 100);
+          const resizedImage = canvas.toDataURL('image/png');
+          setUser({ ...user, image: resizedImage });
+        };
       };
       reader.readAsDataURL(file);
     }
@@ -198,6 +208,7 @@ const UserProfile = () => {
               alt="User Image"
               src={user.image}
               sx={{ width: '15vh', height: '15vh', mr: 2 }}
+              data-testid="avatar"
             />
             <IconButton
               sx={{
@@ -214,7 +225,7 @@ const UserProfile = () => {
               component="label"
             >
               <EditIcon />
-              <input type="file" hidden accept="image/*" onChange={handleImageChange} />
+              <input type="file" hidden accept="image/*" onChange={handleImageChange}/>
             </IconButton>
           </Box>
 


### PR DESCRIPTION
Fixes #30

**What was changed?**

For this issue, I modified the UserProfile page of the application. Previously, any image that was uploaded by the user was saved as their profile picture. My modifications to the UserProfile page ensures that any profile picture uploaded by the user is converted into a 100x100 image before saving it as the user's avatar. I also created a simple unit test to check if the user's avatar successfully changes.

**Why was it changed?**

Originally, an error occurred when trying to change the profile picture in the UserProfile page. This would happen because the size of the profile picture being uploaded exceeded the size limit of the server. This would also cause the terminal to display "PayloadTooLargeError: request entity too large." My code aims to fix this problem by resizing the profile picture to be 100x100 before it is saved. This ensures that any profile picture, including large profile pictures, are made small enough that they don't exceed size limits and cause errors. A unit test that changed the user's avatar was added to ensure that updates to the user avatar are possible. 

**How was it changed?**

The first file I modified was UserProfile.js. Within this file, I focused on updating the handleImageChange function. The function first checks if the user has uploaded an image file. A FileReader object then converts the image into a Base64-encoded URL. Next an image object is created and its src attribute is set to the Base64-encoded URL. A 100x100 <canvas> element is used to resize the image object. Lastly, the resized image is saved. The second file I modified was UserProfile.test.js. I created a new unit test that initialized mock image data and checked whether the src attribute of the avatar element could be changed. To access the avatar element in my unit test, I had to add data-testid="avatar" within UserProfile.js.

**Screenshots that show the changes (if applicable):**

![image](https://github.com/user-attachments/assets/decde288-2262-4442-9a16-fe3764a0286e)
![image](https://github.com/user-attachments/assets/b304906b-2589-4862-a880-f9d538c59e2b)

